### PR TITLE
GSoC: docs(2026): add contributor starter playbook and structured-clone template pack

### DIFF
--- a/2026/README.md
+++ b/2026/README.md
@@ -16,6 +16,16 @@ Here's the list of project ideas for GSoC 2026! Click on the title for a more de
 * [Document Picture-in-Picture for browser meetings](document-pip-browser.md)
 * [Multi-screen support](multi-screen-support.md)
 
+## New contributors: start here
+
+If you are applying for GSoC and want a concrete execution path, read:
+
+* [GSoC 2026 Contributor Starter Playbook](contributor-starter-playbook.md)
+
+Recommended first project path for many applicants:
+
+* [External API with non-serialized postMessages](external-api-structured-clone.md)
+
 # Interested in applying for a project?
 
 Jitsi GSoC’26 Application Guidelines

--- a/2026/contributor-starter-playbook.md
+++ b/2026/contributor-starter-playbook.md
@@ -1,0 +1,81 @@
+# GSoC 2026 Contributor Starter Playbook
+
+This playbook is for applicants who want a concrete path from "interested" to "credible contributor".
+
+## Goal
+
+Demonstrate three things early:
+
+1. You can run the project locally and validate changes.
+2. You can communicate clearly with mentors and the community.
+3. You can deliver small, correct, reviewable pull requests.
+
+## Week 1: Foundation
+
+1. Pick one target idea from [README.md](README.md).
+2. Read the contribution policy in [../CONTRIBUTING.md](../CONTRIBUTING.md).
+3. Join existing GSoC 2026 discussions on the community forum.
+4. Set up the target repository locally and run the baseline build/tests.
+
+Deliverable:
+
+* A short personal log with setup notes, blockers, and how you solved them.
+
+## Week 2: First accepted contribution
+
+1. Start with a small, real issue (docs/tests/low-risk bug fix) in your target codebase.
+2. Open a PR with title prefix `GSoC:`.
+3. Include reproduction or validation steps.
+4. Keep the PR focused to one logical change.
+
+Deliverable:
+
+* First reviewable PR with clear before/after behavior.
+
+## Week 3: Idea-aligned contribution
+
+1. Build a small contribution directly related to your chosen 2026 idea.
+2. Add tests for the changed behavior.
+3. Share trade-offs and alternatives in the PR description.
+
+Deliverable:
+
+* Second PR that demonstrates domain understanding, not only coding.
+
+## Week 4: Proposal draft from evidence
+
+1. Turn your contributions into a milestone-based proposal.
+2. Add measurable success criteria for each milestone.
+3. List technical risks and fallback plans.
+
+Deliverable:
+
+* A proposal draft grounded in real repository work.
+
+## PR checklist for applicants
+
+* Title starts with `GSoC:`.
+* Builds and lint checks pass.
+* Includes reproduction/validation steps.
+* Explains expected behavior and actual behavior.
+* Avoids unrelated refactors.
+* Keeps at most 3 active PRs at a time.
+
+## Communication checklist
+
+* Ask questions in existing GSoC 2026 forum threads.
+* Avoid posting full proposal details publicly.
+* Do not repeatedly ping mentors for review.
+* Prefer precise technical questions over broad requests.
+
+## Recommended first technical path
+
+For many applicants, a strong medium-difficulty starting point is:
+
+* [External API with non-serialized postMessages](external-api-structured-clone.md)
+
+Why this path works:
+
+* Clear scope and measurable impact.
+* Strong TypeScript/Web API learning value.
+* Good balance between complexity and reviewability.

--- a/2026/external-api-structured-clone-pr-template.md
+++ b/2026/external-api-structured-clone-pr-template.md
@@ -1,0 +1,150 @@
+# External API Structured Clone - First PR Template Pack
+
+This page gives you copy-paste friendly text for your first GSoC PRs on the External API structured clone project.
+
+## PR 1: Benchmark harness
+
+Suggested title:
+
+GSoC: feat(external-api): add benchmark harness for JSON vs structured clone messaging
+
+Suggested branch name:
+
+gsoc26/external-api-structured-clone-benchmark
+
+Suggested PR description:
+
+### Summary
+
+This PR adds a benchmark harness to compare message handling performance between:
+
+- JSON serialize and parse flow
+- structured clone flow
+
+The goal is to establish a reproducible baseline before migration work.
+
+### Why
+
+The External API currently relies on JSON serialization for iframe communication. Structured clone can reduce overhead and support richer payloads, but we need baseline numbers before making behavior changes.
+
+### Changes in this PR
+
+- Adds benchmark utility for representative message payloads.
+- Covers small, medium, and large payload classes.
+- Prints timing summaries in a consistent format for local comparison.
+- Adds short documentation for running benchmarks locally.
+
+### Validation
+
+- Ran benchmark locally multiple times and confirmed stable output format.
+- Verified benchmark includes both JSON and structured clone paths.
+- Confirmed no runtime behavior changes in production message handling.
+
+### Out of scope
+
+- No migration of production message handling in this PR.
+- No API shape changes.
+
+---
+
+## PR 2: Typed array round-trip tests
+
+Suggested title:
+
+GSoC: test(external-api): add structured clone round-trip tests for typed arrays
+
+Suggested branch name:
+
+gsoc26/external-api-structured-clone-typed-array-tests
+
+Suggested PR description:
+
+### Summary
+
+This PR adds tests that verify structured clone message paths correctly round-trip binary-friendly data types.
+
+### Why
+
+JSON serialization is not suitable for all binary payloads. We need reliable coverage for richer data types before enabling structured clone paths broadly.
+
+### Changes in this PR
+
+- Adds test cases for typed array payloads.
+- Verifies data integrity after parent to iframe and iframe to parent message round-trips.
+- Adds negative tests for unsupported payload shapes where applicable.
+
+### Validation
+
+- Ran the relevant test suite locally.
+- Verified typed array contents and lengths are preserved after round-trip.
+- Confirmed existing JSON-based tests continue to pass.
+
+### Out of scope
+
+- No transferable ownership optimization in this PR.
+- No backward compatibility removal.
+
+---
+
+## PR 3: Backward compatibility fallback tests
+
+Suggested title:
+
+GSoC: test(external-api): cover fallback behavior for legacy serialized payloads
+
+Suggested branch name:
+
+gsoc26/external-api-structured-clone-fallback-tests
+
+Suggested PR description:
+
+### Summary
+
+This PR adds compatibility tests to ensure legacy integrations that still send serialized payloads continue to work.
+
+### Why
+
+Migration must be safe for existing users. Compatibility behavior needs test coverage before rollout.
+
+### Changes in this PR
+
+- Adds tests for old serialized payload paths.
+- Verifies fallback behavior when structured clone path is unavailable or disabled.
+- Verifies event and command handling parity across old and new paths.
+
+### Validation
+
+- Ran the targeted test suite locally.
+- Confirmed behavior parity for representative commands and events.
+- Confirmed no regressions in existing integration tests.
+
+### Out of scope
+
+- No removal of legacy path.
+- No deprecation switch in this PR.
+
+---
+
+## Universal checklist before opening each PR
+
+- Title starts with GSoC:.
+- One logical change only.
+- Build and lint pass locally.
+- Tests for changed behavior are included.
+- PR description explains why, what changed, and what was validated.
+- Reproduction or validation steps are clear.
+- No unrelated refactors.
+
+## Comment template for mentor discussion thread
+
+I am planning a small contribution for the External API structured clone project.
+
+Proposed PR scope:
+- scope line 1
+- scope line 2
+
+Validation plan:
+- validation line 1
+- validation line 2
+
+If this scope looks good, I will submit a focused PR with GSoC prefix and tests.

--- a/2026/external-api-structured-clone.md
+++ b/2026/external-api-structured-clone.md
@@ -36,3 +36,49 @@ Medium (175 hours)
 
 Medium
 
+## Suggested execution plan (for applicants)
+
+The steps below are a practical path to begin contributing and reduce risk.
+
+### Phase 0: Discovery and baseline
+
+* Locate all parent <-> iframe API message paths and classify message types.
+* Measure baseline serialization overhead for small and large payloads.
+* Document browser compatibility assumptions for structured clone and transferables.
+
+### Phase 1: Core migration
+
+* Replace JSON serialization with structured clone where behavior is equivalent.
+* Add explicit message schema validation for high-risk commands/events.
+* Keep a compatibility path for legacy integrations that still expect serialized payloads.
+
+### Phase 2: Transferable objects
+
+* Introduce transferables only where they provide real benefit and low complexity.
+* Cover ArrayBuffer and similar binary-heavy paths first.
+* Validate object lifetime rules after transfer to avoid use-after-transfer bugs.
+
+### Phase 3: Validation and rollout
+
+* Add integration tests for mixed old/new client behavior.
+* Add docs and examples showing structured clone payloads.
+* Add rollout notes and guardrails for safe incremental adoption.
+
+## First PR ideas
+
+* Add a benchmark harness for comparing JSON serialization vs structured clone in representative API calls.
+* Add tests that verify non-JSON-safe data (for example typed arrays) can round-trip correctly.
+* Add compatibility tests for fallback behavior when integrations send old payload formats.
+
+## Ready-to-use PR draft
+
+Use this template pack to submit your first contributions quickly:
+
+* [External API Structured Clone - First PR Template Pack](external-api-structured-clone-pr-template.md)
+
+## Success metrics
+
+* Lower average message processing time on large payload paths.
+* No regressions in existing External API integrations.
+* Green test coverage for structured clone and fallback paths.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,176 @@
+# How to Contribute
+
+We greatly appreciate your willingness to contribute. Before you start, please read this guide.
+
+## Reporting Issues and Asking Questions
+
+Please discuss issues first in the community forum. Once confirmed, open an issue in the appropriate GitHub project repository.
+
+- Report bugs, request features, or ask for help.
+- When opening an issue, provide as much detail as possible.
+- Ask general and implementation-specific questions in the community forum.
+
+## Bug Reports and Other Issues
+
+For bugs, please include:
+
+1. Detailed version information for Jitsi Meet, Jicofo, and JVB.
+2. A clear description of the issue.
+3. Reproduction steps.
+4. Expected behavior.
+5. Actual behavior, including error messages.
+
+## Feature Requests
+
+If you have a new idea or improvement request, include:
+
+1. Feature description and desired functionality.
+2. Examples from other apps (if relevant).
+3. Why the feature is important.
+4. Potential implementation challenges.
+5. Any additional preferences or details.
+
+## Code Contributions
+
+Start by checking open issues in the relevant tracker (for example, Jitsi Meet's issue tracker).
+
+If you discovered a bug or have a feature request and know how to fix it, review the Developer Guide to set up your environment and begin work.
+
+## Contributor License Agreement (CLA)
+
+Jitsi projects are released under Apache License 2.0, and the copyright holder and principal creator is 8x8.
+
+To accept your contribution, you must sign the Apache-based contributor license agreement as an individual or as a corporation. If you cannot accept the CLA terms, we cannot accept the contribution.
+
+## Creating Pull Requests
+
+1. Fork the repository to your GitHub account.
+2. Create a descriptive branch from `master`.
+3. Make one logical change per pull request.
+4. Keep commit history clean and concise (squash if needed).
+5. Rebase onto the latest `master` before submitting.
+6. Never merge `master` into your branch; always rebase.
+
+## Commit Messages
+
+Jitsi projects follow Conventional Commits with a mandatory scope.
+
+- Preferred: `feat(feature-name): add some functionality`
+- Not preferred: `feat: add some functionality`
+
+Supported commit types include:
+
+- `build`
+- `chore`
+- `ci`
+- `docs`
+- `feat`
+- `fix`
+- `perf`
+- `refactor`
+- `revert`
+- `style`
+- `test`
+
+Scope naming can vary by project and subsystem.
+
+- In Jitsi Meet, a scope can be a feature path such as `react/features/<feature>`.
+- In lib-jitsi-meet, a scope can be a module path such as `modules/<module>`.
+
+Use your judgment and review commit history when unsure.
+
+### For 8x8 Employees
+
+Do not link internal resources such as Jira issues. This is an open source project.
+
+## Coding Style
+
+### Comments
+
+- Source code comments are required.
+- Auto-generated documentation comments (for tools like JSDoc, Javadoc, Doxygen) should follow tool conventions.
+- Non-generated comments are strongly encouraged when they improve understanding.
+- Write comments as proper English sentences with capitalization and punctuation.
+
+### Duplication
+
+- Avoid copy-pasting source code.
+- Prefer reuse, but avoid introducing poor abstractions for minimal reuse.
+
+### Naming
+
+- Use one consistent name for an abstraction across the project(s).
+- For example, a `JitsiConnection` instance should be named `connection` or `jitsiConnection`, not `client`.
+- Keep class names and file names aligned (for example, class `ReducerRegistry` in `ReducerRegistry.js`).
+- Use uppercase with underscores for global constants, for example `BACKGROUND_COLOR`.
+- Leading underscore in names indicates non-public/internal members.
+
+## TypeScript
+
+### Feature Layout
+
+When adding a new feature, use this structure:
+
+```text
+react/features/sample/
+|- actionTypes.ts
+|- actions.ts
+|- components/
+|  |- AnotherComponent.tsx
+|  `- OneComponent.tsx
+|- middleware.ts
+`- reducer.ts
+```
+
+- All new features must be written in TypeScript.
+- When working on older features, converting JavaScript to TypeScript is encouraged.
+- Import middleware in `react/features/app/` in `middlewares.any`, `middlewares.native.js`, or `middlewares.web.js` as appropriate.
+- Import reducers in the appropriate app wiring location as well.
+
+### Index File Guidance
+
+In general, avoid index files and prefer full import paths.
+
+Exception: when common code must import platform-specific components, create:
+
+- `components/index.native.ts`
+- `components/index.web.ts`
+
+Export only what is needed, and import common code from `components/index`.
+
+Older code may not follow this pattern, but new features should. Migrating older features is encouraged when practical.
+
+### Avoiding Bundle Bloat
+
+If a new feature causes a bundle-size-related build failure, analyze first before increasing limits.
+
+1. Build with analysis enabled:
+
+```bash
+npx webpack -p --analyze-bundle
+```
+
+2. Open the analyzer:
+
+```bash
+npx webpack-bundle-analyzer build/app-stats.json
+```
+
+## Kotlin
+
+For Kotlin code, use standard Kotlin conventions and keep line length at 120 characters. Formatting is enforced with `ktlint`.
+
+## Code Reviews
+
+1. Submit your contribution.
+2. Consider opening a draft PR early for design and implementation discussion.
+3. Appropriate reviewers are assigned based on affected code areas.
+4. Reviewers evaluate standards, correctness, performance, and risk.
+5. Address feedback and iterate.
+6. Once the PR is in good shape, a team member triggers automated tests.
+7. The PR must merge cleanly on top of `master`, and failing checks must be fixed before approval.
+8. After review and test success, the PR is approved for merge.
+
+## Issue Closing
+
+You can close issues automatically using GitHub closing keywords in pull requests and commit messages.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # GSoC with Jitsi 
 
 This repository contains the project ideas for GSoC. The archive contains ideas for previous years. See [here](2026/README.md) for the list this year!
+
+Please review the contribution guide in [CONTRIBUTING.md](CONTRIBUTING.md) before submitting changes.


### PR DESCRIPTION
## Summary
This PR improves the GSoC 2026 contributor onboarding flow with concrete, execution-ready guidance.

## Changes
- Add top-level contribution guide at .
- Add a 2026 starter guide at .
- Expand  with a phased execution plan, first PR ideas, and success metrics.
- Add  with copy-paste PR templates.
- Add discoverability links in  and .

## Why
New contributors need a practical path from project idea selection to first reviewable PR. This change turns the idea list into actionable guidance while preserving existing project descriptions.

## Validation
- Verified markdown links and structure locally.
- Scope is documentation-only with no code-path changes.
